### PR TITLE
Move assimp to a static lib

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -132,14 +132,17 @@ expanded it to use a model instead of the simple geometry
 I had previously defined.
 I actually used the
 [SaschaWillems/Vulkan repo](https://github.com/SaschaWillems/Vulkan)
-as a reference while hooking up this functionality.
+as a reference while hooking up this functionality,
+and used the [Open Asset Import Library](https://github.com/assimp/assimp)
+for the actual work.
+I highly recommend that you chek out Sasha Willem's work.
 He's got some amazing code there and I highly recommend you using
 his repo for some advanced learning.
 
 The sample does the following:
  * Use a camera (defined as position and orientation) to
    generate both a projection and view matrix.
- * Load a model file from the resources.
+ * Load a model file from the resources using Assimp.
  * Use a dynamic uniform buffer to pass along the camera
    projection and view matrices to the shader.
  * Use push constants to define the current model matrix.

--- a/submodules/CMakeLists.txt
+++ b/submodules/CMakeLists.txt
@@ -1,3 +1,4 @@
 option(ASSIMP_BUILD_ASSIMP_TOOLS "" OFF)
 option(ASSIMP_BUILD_TESTS "" OFF)
+option(BUILD_SHARED_LIBS "" OFF)
 add_subdirectory(assimp)


### PR DESCRIPTION
On Windows, it was asking me to move the DLL into the samples
folder to run the 07_simple_model_glm sample.  Instead, I moved
it to use a static library.

Also, updated a little verbage to indicate I'm using Assimp to
do the actual model loading work.